### PR TITLE
Import Iterable from collections.abc following deprecation

### DIFF
--- a/basisgen/algebras.py
+++ b/basisgen/algebras.py
@@ -1,7 +1,7 @@
 from basisgen.weights import Weight
 
 import abc
-import collections
+from collections.abc import Iterable
 import enum
 import functools
 import itertools
@@ -335,7 +335,7 @@ class SimpleAlgebra(Algebra):
             return [10, 6]
 
 
-class SemisimpleAlgebra(collections.Iterable, Algebra):
+class SemisimpleAlgebra(Iterable, Algebra):
     def __init__(self, simple_algebras):
         self.simple_algebras = simple_algebras
         self.rank = sum(


### PR DESCRIPTION
The `Iterable` abstract class was removed from collections in Python 3.10. See the deprecation note in the 3.9 collections docs: https://docs.python.org/3.9/library/collections.html. 

Here I've just changed the import to be from `collections.abc`, so that the code still runs on Python versions > 3.9.